### PR TITLE
use commons-logging as spring does

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
             <optional>true</optional>
@@ -67,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>Mockito-all</artifactId>
+            <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/ch/sbb/esta/openshift/gracefullshutdown/GracefulShutdownHealthCheck.java
+++ b/src/main/java/ch/sbb/esta/openshift/gracefullshutdown/GracefulShutdownHealthCheck.java
@@ -4,8 +4,8 @@
 
 package ch.sbb.esta.openshift.gracefullshutdown;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 
@@ -20,7 +20,7 @@ import org.springframework.boot.actuate.health.HealthIndicator;
  * removing it from the service.
  */
 public class GracefulShutdownHealthCheck implements HealthIndicator, IProbeController {
-    Logger log = LoggerFactory.getLogger(GracefulShutdownHealthCheck.class.getName());
+    private static final Log log = LogFactory.getLog(GracefulShutdownHealthCheck.class);
 
     public static final String GRACEFULSHUTDOWN = "Gracefulshutdown";
     private Health health;

--- a/src/main/java/ch/sbb/esta/openshift/gracefullshutdown/GracefulShutdownHook.java
+++ b/src/main/java/ch/sbb/esta/openshift/gracefullshutdown/GracefulShutdownHook.java
@@ -4,8 +4,8 @@
 
 package ch.sbb.esta.openshift.gracefullshutdown;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.util.StringUtils;
 
@@ -32,7 +32,8 @@ import java.util.Map;
 class GracefulShutdownHook implements Runnable {
     protected static final String GRACEFUL_SHUTDOWN_WAIT_SECONDS = "estaGracefulShutdownWaitSeconds";
     private static final String DEFAULT_GRACEFUL_SHUTDOWN_WAIT_SECONDS = "20";
-    private static Logger log = LoggerFactory.getLogger(GracefulShutdownHook.class.getName());
+
+    private static final Log log = LogFactory.getLog(GracefulShutdownHook.class);
 
     private final ConfigurableApplicationContext applicationContext;
 


### PR DESCRIPTION
The library should use the same logging api as spring does and not introduce a new transitive dependency to slf4j. If needed, this should be done in the implementing application.