### PR TITLE
make GracefulShutdownHook public

### DIFF
--- a/src/main/java/ch/sbb/esta/openshift/gracefullshutdown/GracefulShutdownHook.java
+++ b/src/main/java/ch/sbb/esta/openshift/gracefullshutdown/GracefulShutdownHook.java
@@ -29,7 +29,7 @@ import java.util.Map;
  *
  * @author ue64007
  */
-class GracefulShutdownHook implements Runnable {
+public class GracefulShutdownHook implements Runnable {
     protected static final String GRACEFUL_SHUTDOWN_WAIT_SECONDS = "estaGracefulShutdownWaitSeconds";
     private static final String DEFAULT_GRACEFUL_SHUTDOWN_WAIT_SECONDS = "20";
 
@@ -37,7 +37,7 @@ class GracefulShutdownHook implements Runnable {
 
     private final ConfigurableApplicationContext applicationContext;
 
-    GracefulShutdownHook(ConfigurableApplicationContext applicationContext) {
+    public GracefulShutdownHook(ConfigurableApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 


### PR DESCRIPTION
I should be possible to use his own SpringApplicationBuilder. In that case the class GracefulShutdownHook has to be public.